### PR TITLE
CustomUserモデルに退部日フィールドを追加

### DIFF
--- a/accounts/admin.py
+++ b/accounts/admin.py
@@ -7,7 +7,7 @@ from .models import CustomUser,Campus,Undergraduate,Departments
  
 class CustomUserAdmin(UserAdmin):
     model = CustomUser
-    fieldsets = UserAdmin.fieldsets + ((None, {'fields': ('qiita_user_id','campus','undergraduate','department','year')}),)
+    fieldsets = UserAdmin.fieldsets + ((None, {'fields': ('qiita_user_id','leave_date','campus','undergraduate','department','year')}),)
     list_display = ['username', 'email', 'year']
  
  

--- a/accounts/models.py
+++ b/accounts/models.py
@@ -27,6 +27,7 @@ class Departments(models.Model):
 
 class CustomUser(AbstractUser):
     qiita_user_id = models.CharField("Qiita_ユーザーID", max_length=30, null=True, blank=True)
+    leave_date = models.DateField("退部日", null=True, blank=True)
     campus = models.ManyToManyField(Campus, "キャンパス")
     undergraduate = models.ManyToManyField(Undergraduate, "学部")
     department = models.ManyToManyField(Departments, "学科")


### PR DESCRIPTION
## issueのリンク
#4 

## 概要
ユーザの退部日を示すleave_dateフィールドを追加した。

## 実現方法
日付なのでDateField型でCustomUserに追加。退部していない人は入力する必要がないため、null=True, blank=Trueになっている。

## 動作確認内容

- [ ] 管理画面のユーザー（"admin/accounts/customuser/[ユーザid]/change"）で「退部日」フィールドを入力・保存。保存でエラーが出ないか

- [ ] 管理画面のユーザー（"admin/accounts/customuser/[ユーザid]/change"）で「退部日」フィールドを入力せずに保存。保存でエラーが出ないか(blank=Trueの確認)

## その他
後々は、leave_dateフィールドを設定した際にパーミッションを"False"に設定するようにする。